### PR TITLE
correction sur mutations

### DIFF
--- a/lib/dragon/search_algorithm/ssea.py
+++ b/lib/dragon/search_algorithm/ssea.py
@@ -133,6 +133,7 @@ class SteadyStateEA(SearchAlgorithm):
                 not_muted = False
             except Exception as e:
                 logger.error(f"While mutating, an exception was raised: {e}")
+        not_muted = True
         while not_muted:
             try:
                 offspring_2 = self.search_space.neighbor(deepcopy(offspring_2))


### PR DESCRIPTION
Seul l'enfant 1 était muté, ou l'enfant 2 si l'enfant 1 ne pouvait pas être muté